### PR TITLE
Use apiServer from globals.ts as a global variable for the API server

### DIFF
--- a/src/app/admin.service.ts
+++ b/src/app/admin.service.ts
@@ -5,6 +5,7 @@ import { HttpClient, HttpHeaders} from '@angular/common/http';
 import {Http, Response, Headers, } from "@angular/http";
 import { Router, CanActivate } from '@angular/router';
 import { MessageService } from './message.service';
+import { apiServer } from './globals';
 /*
 this service takes care of Administrator logins. Due to issues with the administration about privacy laws
 and such, login functionality for students and administrators are currently split between two services
@@ -27,7 +28,7 @@ export class AdminService {
       
       let body = JSON.stringify({username:username, password:password});
       console.log('this is username in service',body)
-      this.http.post<any>("http://localhost:8080/api/admin/login",body,{headers: headers}).subscribe(
+      this.http.post<any>(apiServer + "/api/admin/login",body,{headers: headers}).subscribe(
         data =>{ this.admin = data;
                   console.log("this is the admin we get",this.admin);
                   if(this.admin.length>0){

--- a/src/app/globals.ts
+++ b/src/app/globals.ts
@@ -1,0 +1,3 @@
+'use strict'
+
+export const apiServer: string = "http://localhost:8080"

--- a/src/app/login.service.ts
+++ b/src/app/login.service.ts
@@ -5,6 +5,7 @@ import { HttpClient, HttpHeaders} from '@angular/common/http';
 import {Http, Response, Headers, } from "@angular/http";
 import { Router, CanActivate } from '@angular/router';
 import { MessageService } from './message.service';
+import { apiServer } from './globals';
 /*
 this service takes care of student logins. Due to issues with the administration about privacy laws
 and such, login functionality for students and administrators are currently split between two services
@@ -25,7 +26,7 @@ export class LoginService implements CanActivate {
       
       let body = JSON.stringify({RCSid:username});
       console.log('this is username in service',body)
-      this.http.post<any>("http://localhost:8080/api/login",body,{headers: headers}).subscribe(
+      this.http.post<any>(apiServer + "/api/login",body,{headers: headers}).subscribe(
         data =>{ this.user = data;
                   console.log("this is the user we get",this.user);
                   console.log("this is the user status",this.user[0].Status.trim());

--- a/src/app/student.service.ts
+++ b/src/app/student.service.ts
@@ -3,6 +3,7 @@ import { Observable } from 'rxjs/Observable';
 import { of } from 'rxjs/observable/of';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Router } from '@angular/router';
+import { apiServer } from './globals';
 
 
 
@@ -15,19 +16,19 @@ export class StudentService {
   // gets active student data from api
   getActive():Observable<any> {
 
-    return this.http.get<any>("http://localhost:8080/api/active_user")
+    return this.http.get<any>(apiServer + "/api/active_user")
   }
 
   // gets inactive student data from api
   getRequest():Observable<any> {
-    return this.http.get<any>("http://localhost:8080/api/inactive_user")
+    return this.http.get<any>(apiServer + "/api/inactive_user")
   }
 
   // adds studet request to db through api
   register(username):void {
     const headers = new HttpHeaders().set( 'Content-Type', 'application/json');
     let body = JSON.stringify({RCSid:username});
-    this.http.post<any>("http://localhost:8080/api/request-access",body,{headers: headers}).subscribe(
+    this.http.post<any>(apiServer + "/api/request-access",body,{headers: headers}).subscribe(
       data =>{
         console.log("user added to Database as request");
       },
@@ -40,7 +41,7 @@ export class StudentService {
   addOne(username):void {
     const headers = new HttpHeaders().set( 'Content-Type', 'application/json');
     let body = JSON.stringify({RCSid:username});
-    this.http.post<any>("http://localhost:8080/api/addtoActive",body,{headers: headers}).subscribe(
+    this.http.post<any>(apiServer + "/api/addtoActive",body,{headers: headers}).subscribe(
       data =>{
         console.log("user added to Database as request");
       },
@@ -52,7 +53,7 @@ export class StudentService {
   // adds all students with request to the active students list
   addAll():void {
     
-    this.http.get<any>("http://localhost:8080/api/addAll").subscribe(
+    this.http.get<any>(apiServer + "/api/addAll").subscribe(
       data =>{
         console.log(" All request users added to Database as Active");
       },
@@ -64,7 +65,7 @@ export class StudentService {
   remove(username):void {
     const headers = new HttpHeaders().set( 'Content-Type', 'application/json');
     let body = JSON.stringify({RCSid:username});
-    this.http.post<any>("http://localhost:8080/api/remove",body,{headers: headers}).subscribe(
+    this.http.post<any>(apiServer + "/api/remove",body,{headers: headers}).subscribe(
       data =>{
         console.log("user removed from Database");
         window.location.reload();
@@ -75,7 +76,7 @@ export class StudentService {
   }
 // lusts the student complaints stored in the db
   listComplaints():Observable<any>{
-    return this.http.get<any>("http://localhost:8080/api/get-complaints")
+    return this.http.get<any>(apiServer + "/api/get-complaints")
 
   }
 
@@ -83,7 +84,7 @@ export class StudentService {
   submitComplaint(location,message,isLI:boolean):void{
     const headers = new HttpHeaders().set( 'Content-Type', 'application/json');
     let body = JSON.stringify({Location:location, Message:message});
-    this.http.post<any>("http://localhost:8080/api/submit-complaint",body,{headers: headers}).subscribe(
+    this.http.post<any>(apiServer + "/api/submit-complaint",body,{headers: headers}).subscribe(
       data =>{
         console.log("complaint added to Database as request");
         if(isLI){


### PR DESCRIPTION
API server is currently hardcoded in several places in several files as localhost:8080. This isn't good for use on a server because these API calls will occur on the client side which is (probably) not running the API server. I've created a file called globals.ts in /src/app which exports the string apiServer which should be set to the location and port of the API server. I've left it as "http://localhost:8080" for simplicity, but it can be easily changed to another ip or a domain name by just changing globals.ts instead of changing each file individually.